### PR TITLE
Safeer xdg-open script

### DIFF
--- a/runescape/templates/packaging/usr/local/bin/xdg-open
+++ b/runescape/templates/packaging/usr/local/bin/xdg-open
@@ -1,15 +1,17 @@
 #!/bin/bash
 
 # Make a tmp folder
-mkdir "/tmp/bin"
+tmpdir=$(mktemp -td xdg-open.XXXX)
 
-# Copy xdg-open
-cp "/usr/bin/xdg-open" "/tmp/bin/"
+if [ $? -eq 0 ]; then
+    # Copy xdg-open
+    cp "/usr/bin/xdg-open" "$tmpdir"
 
-# Patch xdg-open
-sed -i -e 's/else DE=""/elif xprop -root 2> \/dev\/null | grep -i ^xfce_desktop_window >\/dev\/null 2>\&1; then DE=xfce;\nelse DE=\"\"/' "/tmp/bin/xdg-open"
+    # Patch xdg-open
+    sed -i -e 's/else DE=""/elif xprop -root 2> \/dev\/null | grep -i ^xfce_desktop_window >\/dev\/null 2>\&1; then DE=xfce;\nelse DE=\"\"/' "$tmpdir/xdg-open"
 
-# Execute xdg-open
-env "/tmp/bin/xdg-open" $@
+    # Execute xdg-open
+    env "$tmpdir/xdg-open" $@
 
-rm -r "/tmp/bin"
+    rm -rf "$tmpdir"
+fi

--- a/runescape/templates/packaging/usr/local/bin/xdg-open
+++ b/runescape/templates/packaging/usr/local/bin/xdg-open
@@ -2,8 +2,9 @@
 
 # Make a tmp folder
 tmpdir=$(mktemp -td xdg-open.XXXX)
+exitcode=$?
 
-if [ $? -eq 0 ]; then
+if [ $exitcode -eq 0 ]; then
     # Copy xdg-open
     cp "/usr/bin/xdg-open" "$tmpdir"
 
@@ -14,4 +15,8 @@ if [ $? -eq 0 ]; then
     env "$tmpdir/xdg-open" $@
 
     rm -rf "$tmpdir"
+    
+else
+    # Pass the exitcode to caller
+    exit $exitcode
 fi


### PR DESCRIPTION
Original file can overwrite/delete user files, if `/tmp/bin/` already exists in the system.
This patch prevents it.