### PR TITLE
Making the adjustments mentioned in #83 and two minor extra ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,43 +30,55 @@ Install instructions
 __Installation on Debian__
 
 1. Open the Terminal program and type in the following commands:
-<pre>echo "deb http://ppa.launchpad.net/hikariknight/unix-runescape-client/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
+```bash
+echo "deb http://ppa.launchpad.net/hikariknight/unix-runescape-client/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9BA73CFA
-sudo apt-get update && sudo apt-get install unix-runescape-client</pre>
+sudo apt-get update && sudo apt-get install unix-runescape-client
+```
 
-__Installation on Ubuntu or Mint__
+__Installation on Ubuntu or Linux Mint__
 
-1. Open the Terminal program and type in the following command:
-<pre>sudo apt-add-repository ppa:hikariknight/unix-runescape-client</pre>
+1. Open the Terminal program and type in the following command:
+```bash
+sudo apt-add-repository ppa:hikariknight/unix-runescape-client
+```
 2. Then once that is done type in the following commands:
-<pre>sudo apt-get update && sudo apt-get install unix-runescape-client</pre>
+```bash
+sudo apt-get update && sudo apt-get install unix-runescape-client
+```
 
 __Installation on ArchLinux__
 
 1. Open the Terminal program and type in the following command:
-<pre>yaourt -S unix-runescape-client</pre>
+```bash
+yaourt -S unix-runescape-client
+```
 
 __Installation on Fedora__
 
 1. Install dependent packages
-<pre>sudo yum install perl "perl(List::MoreUtils)" "perl(Config::IniFiles)" "perl(Archive::Extract)" "perl-Wx"</pre>
+```bash
+sudo dnf install perl "perl(List::MoreUtils)" "perl(Config::IniFiles)" "perl(Archive::Extract)" "perl-Wx"
+```
 
 2. Download and extract the universal archive.
 
-__Installation on OpenSUSE__
+__Installation on openSUSE__
 
 1. Install dependent packages
-<pre>sudo zypper in perl "perl(List::MoreUtils)" "perl(Config::IniFiles)" "perl(Archive::Extract)"</pre>
+```bash
+sudo zypper in perl "perl(List::MoreUtils)" "perl(Config::IniFiles)" "perl(Archive::Extract)"
+```
 
 2. Download and extract the universal archive.
 
-__Installation on Gentoo__
+__Installation on Gentoo Linux__
 
 1. Follow JohnPeel's guide [here](https://github.com/JohnPeel/dgby-overlay/wiki/Installing-rsu-client-on-Gentoo) on how to install the RSU-Client on Gentoo 
 
 or:
 
-1. Install Layman, if it is not already installed, with:
+1. Install [Layman](https://wiki.gentoo.org/wiki/Layman), if it is not already installed, with:
 ```bash
 sudo emerge -av layman
 ```

--- a/README.md
+++ b/README.md
@@ -64,14 +64,33 @@ __Installation on Gentoo__
 
 1. Follow JohnPeel's guide [here](https://github.com/JohnPeel/dgby-overlay/wiki/Installing-rsu-client-on-Gentoo) on how to install the RSU-Client on Gentoo 
 
+or:
+
+1. Install Layman, if it is not already installed, with:
+```bash
+sudo emerge -av layman
+```
+2. Add the `sabayon` overlay with:
+```bash
+sudo layman -a sabayon
+```
+3. Emerge the RSU Client:
+```bash
+sudo emerge -av games-rpg/unix-runescape-client
+```
+
+__Installation on Sabayon__
+Provided the sabayonlinux.org repository is enabled, merely run:
+```bash
+sudo equo i games-rpg/unix-runescape-client
+```
+
 __Other Linux systems__
 
 Please use the bitrock installer or universal archive.
 The RSU-Client is not officially supported on other Linux systems
 due to the lack of package maintainers for those systems.
 Also the RSU-Client may not work correctly on other Linux systems due to missing packages
-
-
 
 About the Project
 ----------


### PR DESCRIPTION
In issue #83 I mentioned that RSU is now in the sabayon overlay and the Entropy repositories, so adding info relating to this to the README. I also changed `<pre>` HTML tags to the equivalent Markdown markup and replaced `yum` with `dnf` in Fedora instructions as DNF is now the package manager of Fedora. 