### PR TITLE
updated suse install with perl packages from the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ __Installation on openSUSE__
 
 * Install dependent packages
 ```bash
-sudo zypper in perl "perl(List::MoreUtils)" "perl(Config::IniFiles)" "perl(Archive::Extract)"
+sudo zypper in perl perl-List-MoreUtils perl-List-moreUtils-XS perl-Config-IniFiles perl-Archive-Extract
 ```
 
 * Download and extract the universal archive.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ __Installation on openSUSE__
 
 * Install dependent packages
 ```bash
-sudo zypper in perl perl-List-MoreUtils perl-List-moreUtils-XS perl-Config-IniFiles perl-Archive-Extract
+sudo zypper in perl perl-List-MoreUtils perl-Config-IniFiles perl-Archive-Extract
 ```
 
 * Download and extract the universal archive.


### PR DESCRIPTION
after installing it from the OBS repo on tumbleweed I tried running your command for installing the suse dependencies. However they didn't work so installed perl-Module-Load-Conditional perl-Exporter-Tiny and Perl-XSLoader and running runescape works from there I plan on updating the OBS builds once the site is back up.