### PR TITLE
Improve the locating of java JRE lib folder

### DIFF
--- a/runescape/rsu/framework/modules/rsu/java/opengl.pm
+++ b/runescape/rsu/framework/modules/rsu/java/opengl.pm
@@ -22,8 +22,11 @@ sub unix_findlibrarypath
 	# Remove the newline from the output
 	#$lddresult =~ s/\n//g;
 	
-	# If the java version is 12
-	if ($version =~ /build 12/i)
+	# Extract the major version from the java build string
+	($version) = $version =~ /.*build (\d+).*/;
+	
+	# If the java version is greater than or equal to 12
+	if ($version >= 12)
 	{
 		# Find the library path for java 12 from the ldd output line and remove
 		# whitespaces before and after the path


### PR DESCRIPTION
My previous fix for locating java JRE lib folder was only good for java versions up to 12 but now the subroutine can work for future java versions too. It is also easier to add new conditions for locating the lib folder for new java versions now that the major version number (e.g. 12) is directly placed in a variable in the subroutine.

Too bad that Jagex is deprecating Java clients because this was the best client out there :disappointed: